### PR TITLE
chore: configure Vercel deployment branches

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -19,5 +19,11 @@
     "dist/main.js": {
       "maxDuration": 30
     }
+  },
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "develop": false
+    }
   }
 }


### PR DESCRIPTION
## Summary
- allow Vercel deployments from `main` only

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: 403 Forbidden for @vercel/node)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a0b0fd2883259b24e71dd57950cc