### PR TITLE
fix: hide email only in user list responses

### DIFF
--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -44,7 +44,6 @@ export class UsersService {
           idMember: true,
           memberName: true,
           realName: true,
-          emailAddress: true,
           dateRegistered: true,
           lastLogin: true,
           posts: true,
@@ -594,15 +593,20 @@ export class UsersService {
       ...otherFields
     } = user;
 
-    return {
+    const sanitized: any = {
       id: idMember,
       username: memberName,
       realName,
-      email: emailAddress,
       registrationDate: dateRegistered,
       lastLogin,
       isAdmin: user.idGroup === 1 || idMember === 1,
       ...otherFields,
     };
+
+    if (emailAddress !== undefined) {
+      sanitized.email = emailAddress;
+    }
+
+    return sanitized;
   }
 }


### PR DESCRIPTION
## Summary
- only omit `emailAddress` when listing users
- include `emailAddress` for single-user queries and mutations
- conditionally expose `email` in `sanitizeUser`

## Testing
- `npm test` *(fails: Nest can't resolve dependencies, multiple service specs failing)*
- `npm run lint` *(fails: thousands of @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b94ba9552883259a98202f69c3f7d1