### PR TITLE
Fix Prisma public lists filter

### DIFF
--- a/src/modules/lists/lists.service.ts
+++ b/src/modules/lists/lists.service.ts
@@ -170,7 +170,7 @@ export class ListsService {
       statut: 1,
       animeOrManga: mediaType,
       ...(type ? { type } : {}),
-      membre: { isNot: null }
+      membre: { idMember: { gt: 0 } }
     };
     const skip = (page - 1) * limit;
     const orderBy: any = sort === 'recent'


### PR DESCRIPTION
## Summary
- replace the invalid Prisma relation filter in the public lists query with an id-based check to keep only entries linked to a member

## Testing
- npx eslint src/modules/lists/lists.service.ts --fix *(fails: existing @typescript-eslint no-unsafe-* violations in file)*

------
https://chatgpt.com/codex/tasks/task_e_68cedf76bcb083259ab6ed2b49068c00